### PR TITLE
Allowing cross-domain requests to the game engine

### DIFF
--- a/game_engine/lib/game_engine/endpoint.ex
+++ b/game_engine/lib/game_engine/endpoint.ex
@@ -35,5 +35,7 @@ defmodule GameEngine.Endpoint do
     key: "_game_engine_key",
     signing_salt: "yVdNYKJs"
 
+  plug GameEngine.AllowCrossDomainRequestsPlug
+
   plug GameEngine.Router
 end

--- a/game_engine/test/controllers/engine_controller_preflight_test.exs
+++ b/game_engine/test/controllers/engine_controller_preflight_test.exs
@@ -1,0 +1,11 @@
+defmodule GameEngine.EngineControllerPreflightTest do
+	use ExUnit.Case
+	use Phoenix.ConnTest
+
+	test "get 200 empty response when a preflight request is sent" do
+		response = GameEngine.EngineController.preflight(conn, %{})
+
+		assert response.status == 200
+		assert response.resp_body == ""
+	end
+end

--- a/game_engine/test/plugs/allow_cross_domain_requests_plug_test.exs
+++ b/game_engine/test/plugs/allow_cross_domain_requests_plug_test.exs
@@ -1,0 +1,35 @@
+defmodule GameEngine.AllowCrossDomainRequestsPlugTest do
+	use ExUnit.Case, async: true
+	use Plug.Test
+
+	@options GameEngine.AllowCrossDomainRequestsPlug.init([])
+
+	@allow_cross_origin "access-control-allow-origin"
+	@allow_headers "access-control-allow-headers"
+	@allow_methods "access-control-allow-methods"
+	
+	test "game engine allows cross-domain requests" do
+		conn = conn(:post, "/move")
+
+		conn = GameEngine.AllowCrossDomainRequestsPlug.call(conn, @options)
+
+		assert get_resp_header(conn, @allow_cross_origin) == ["*"]
+	end
+
+	test "game engine allows http headers when request are cross-domain" do
+		conn = conn(:post, "/move")
+
+		conn = GameEngine.AllowCrossDomainRequestsPlug.call(conn, @options)
+
+		assert get_resp_header(conn, @allow_headers) == ["content-type, access-control-allow-headers, authorization, x-requested-with"]
+	end
+
+	test "game engine allows all http methods when request are cross-domain" do
+		conn = conn(:post, "/move")
+
+		conn = GameEngine.AllowCrossDomainRequestsPlug.call(conn, @options)
+
+		assert get_resp_header(conn, @allow_methods) == ["get, post, put, delete, options"]
+	end
+
+end

--- a/game_engine/web/controllers/engine_controller.ex
+++ b/game_engine/web/controllers/engine_controller.ex
@@ -1,9 +1,9 @@
 defmodule GameEngine.EngineController do
 	use GameEngine.Web, :controller
 
-	def nothing(conn, _params) do
+	def preflight(conn, _params) do
 		conn
-		|> json(%{status: "ok"})
+		|> send_resp(200, "")
 	end
 
 	def start(conn, params) do

--- a/game_engine/web/controllers/engine_controller.ex
+++ b/game_engine/web/controllers/engine_controller.ex
@@ -1,6 +1,11 @@
 defmodule GameEngine.EngineController do
 	use GameEngine.Web, :controller
 
+	def nothing(conn, _params) do
+		conn
+		|> json(%{status: "ok"})
+	end
+
 	def start(conn, params) do
 		case GameEngine.Game.start(:game, get_players(params)) do
 			{:ok, game} ->

--- a/game_engine/web/plugs/allow_cross_domain_requests_plug.ex
+++ b/game_engine/web/plugs/allow_cross_domain_requests_plug.ex
@@ -1,0 +1,19 @@
+defmodule GameEngine.AllowCrossDomainRequestsPlug do
+	import Plug.Conn
+
+	@allow_cross_origin "access-control-allow-origin"
+	@allow_headers "access-control-allow-headers"
+	@allow_methods "access-control-allow-methods"
+
+	
+	def init(options), do: options
+
+ 	def call(conn, _options) do
+ 		conn = conn 
+ 		|> put_resp_header(@allow_cross_origin, "*")
+ 		|> put_resp_header(@allow_headers, "content-type, access-control-allow-headers, authorization, x-requested-with")
+ 		|> put_resp_header(@allow_methods, "get, post, put, delete, options")
+
+ 		conn
+ 	end
+end

--- a/game_engine/web/router.ex
+++ b/game_engine/web/router.ex
@@ -9,9 +9,10 @@ defmodule GameEngine.Router do
     pipe_through :api
 
     post "/start", EngineController, :start
-    options "/start", EngineController, :nothing
+    options "/start", EngineController, :preflight
 
     post "/move/:game_id", EngineController, :move
+    options "/move/:game_id", EngineController, :preflight
   end
   
 end

--- a/game_engine/web/router.ex
+++ b/game_engine/web/router.ex
@@ -9,6 +9,7 @@ defmodule GameEngine.Router do
     pipe_through :api
 
     post "/start", EngineController, :start
+    options "/start", EngineController, :nothing
 
     post "/move/:game_id", EngineController, :move
   end


### PR DESCRIPTION
Allowing CORS by setting allow-access-origin, headers and methods. 
In order to achieve it I have created a simple plug that just adds the required parameters into the response, this way the browser knows that the request is permitted.

In addition, browser makes a "preflight" request before the actual request in order to check if the actual one will be possible. This is done through a Option http request to the same endpoint. 
In this case I have added a dummy handler for the option preflight request with empty response and 200. 
But since it goes through the same piped plug, it contains all the CORS artifacts.

There are some packages like Corsiga and PlugCors available. They allow a more fine detailed specification of what it is allowed for every origin. I have opted to create a simple one for now.
