### PR TITLE
Fixing warnings, mostly not used vars that can be ignored with _.

### DIFF
--- a/game_engine/lib/game_engine/board.ex
+++ b/game_engine/lib/game_engine/board.ex
@@ -38,7 +38,7 @@ defmodule GameEngine.Board do
 													 _, player, _,
 													 _, _, player}}) when player in @players, do: {:winner, player}
 
-	def resolve_winner(%GameEngine.Board{positions: positions}) do
+	def resolve_winner(%GameEngine.Board{positions: _positions}) do
 		{:no_winner}
 	end
 
@@ -83,14 +83,6 @@ defmodule GameEngine.Board do
 		chunk_columns(first_column, second_column, third_column)
 	end
 
-	def get_columns(%GameEngine.Board{positions: positions}) do
-		{first_column, tail} = group_first_column(positions)
-
-		{second_column, third_column} = group_second_third(tail)
-
-		chunk_columns(first_column, second_column, third_column)
-	end
-
 	def get_diagonals(%GameEngine.Board{positions: {c1, _, c2,
 													_, c3, _,
 													c4, _, c5}}), do: [[c1, c3, c5], [c2, c3, c4]]
@@ -123,17 +115,17 @@ defmodule GameEngine.Board do
 		positions
 		|> Tuple.to_list
 		|> Enum.with_index
-		|> Enum.partition(fn({mark, index}) -> rem(index, 3) == 0 end)
+		|> Enum.partition(fn({_mark, index}) -> rem(index, 3) == 0 end)
 	end
 
 	defp group_second_third(second_third) do
 		second_third
-		|> Enum.partition(fn({mark, index}) -> rem(index, 3) == 1 end)
+		|> Enum.partition(fn({_mark, index}) -> rem(index, 3) == 1 end)
 	end
 
 	defp chunk_columns(first_column, second_column, third_column) do
 		first_column ++ second_column ++ third_column
-		|> Enum.map(fn({mark, index}) -> mark end)
+		|> Enum.map(fn({mark, _index}) -> mark end)
 		|> Enum.chunk(3)
 	end
 

--- a/game_engine/lib/game_engine/game.ex
+++ b/game_engine/lib/game_engine/game.ex
@@ -22,7 +22,7 @@ defmodule GameEngine.Game do
 		{:ok, state}
 	end
 
-	def handle_call({:start, %{o: %{name: o_name, type: o_type}, x: %{name: x_name, type: x_type}, first_player: first_player}}, _from, state) do
+	def handle_call({:start, %{o: %{name: o_name, type: o_type}, x: %{name: x_name, type: x_type}, first_player: first_player}}, _from, _state) do
 		game_id = GameEngine.GameIdGenerator.new
 
 		type_of_game = get_type_of_game(o_type, x_type)
@@ -43,13 +43,13 @@ defmodule GameEngine.Game do
 		{:reply, {:ok, %{state | next_player: get_player_name(next_player, o_name, x_name)}}, state}
 	end
 
-	def handle_call({:move, game_id}, _from, state) do
+	def handle_call({:move, _game_id}, _from, state) do
 		{:ok, board_after_move} = GameEngine.Player.move(state[:next_player], state[:board])
 
 		handle_move(state, board_after_move)
 	end
 
-	def handle_call({:move, game_id, move}, _from, state) do
+	def handle_call({:move, _game_id, move}, _from, state) do
 		{:ok, board_after_move} = GameEngine.Player.move(state[:next_player], state[:board], move)
 
 		handle_move(state, board_after_move)
@@ -62,10 +62,6 @@ defmodule GameEngine.Game do
 	defp get_type_of_game(:computer, :human),  do: :human_computer
 
 	defp get_type_of_game(:human, :human),  do: :human_human
-
-	defp first_player_part_of_game?(state, first_player) do
-		state[:o] == first_player || state[:x] == first_player
-	end
 
 	defp handle_move(state, board_after_move) do
 		{new_state, response} = process_move(state[:next_player], board_after_move, state)
@@ -109,9 +105,9 @@ defmodule GameEngine.Game do
 	defp winner?({:winner, _winner}), do: true
 	defp winner?({:no_winner}), do: false
 
-	defp get_next_player(o, x, first_player) when first_player == o, do: :o
-	defp get_next_player(o, x, first_player) when first_player == x, do: :x
+	defp get_next_player(o, _x, first_player) when first_player == o, do: :o
+	defp get_next_player(_o, x, first_player) when first_player == x, do: :x
 
-	defp get_player_name(:o, o, x), do: o
-	defp get_player_name(:x, o, x), do: x
+	defp get_player_name(:o, o, _x), do: o
+	defp get_player_name(:x, _o, x), do: x
 end

--- a/game_engine/lib/game_engine/play_strategies/kickass_opponents_opposite_corner_moves.ex
+++ b/game_engine/lib/game_engine/play_strategies/kickass_opponents_opposite_corner_moves.ex
@@ -18,5 +18,5 @@ defmodule GameEngine.PlayStrategies.KickAssOpponentsOppositeCornerMoves do
 
 	def find_corner(%GameEngine.Board{positions: {_, _, _,
 						 					  	  _, _, _,
-						 					  	  _, _, _}}, opponent), do: nil
+						 					  	  _, _, _}}, _opponent), do: nil
 end

--- a/game_engine/lib/game_engine/play_strategies/kickass_win_moves.ex
+++ b/game_engine/lib/game_engine/play_strategies/kickass_win_moves.ex
@@ -19,7 +19,7 @@ defmodule GameEngine.PlayStrategies.KickAssWinMoves do
 		end
 	end
 
-	defp horizontal_win([], player), do: nil
+	defp horizontal_win([], _player), do: nil
 
 	defp horizontal_win([[nil, mark, mark]], player) when player == mark, do: %{row: 2, column: 0}
 	defp horizontal_win([[mark, nil, mark]], player) when player == mark, do: %{row: 2, column: 1}
@@ -29,14 +29,14 @@ defmodule GameEngine.PlayStrategies.KickAssWinMoves do
 	defp horizontal_win([[mark, nil, mark], [_, _, _]], player) when player == mark, do: %{row: 1, column: 1}
 	defp horizontal_win([[mark, mark, nil], [_, _, _]], player) when player == mark, do: %{row: 1, column: 2}
 
-	defp horizontal_win([[nil, mark, mark]|tail], player) when player == mark, do: %{row: 0, column: 0}
-	defp horizontal_win([[mark, nil, mark]|tail], player) when player == mark, do: %{row: 0, column: 1}
-	defp horizontal_win([[mark, mark, nil]|tail], player) when player == mark, do: %{row: 0, column: 2}
+	defp horizontal_win([[nil, mark, mark]|_tail], player) when player == mark, do: %{row: 0, column: 0}
+	defp horizontal_win([[mark, nil, mark]|_tail], player) when player == mark, do: %{row: 0, column: 1}
+	defp horizontal_win([[mark, mark, nil]|_tail], player) when player == mark, do: %{row: 0, column: 2}
 
 	defp horizontal_win([[_, _, _]|tail], player) , do: horizontal_win(tail, player)
 
 
-	defp vertical_win([], player), do: nil
+	defp vertical_win([], _player), do: nil
 
 	defp vertical_win([[nil, mark, mark]], player) when player == mark, do: %{row: 0, column: 2}
 	defp vertical_win([[mark, nil, mark]], player) when player == mark, do: %{row: 1, column: 2}
@@ -46,9 +46,9 @@ defmodule GameEngine.PlayStrategies.KickAssWinMoves do
 	defp vertical_win([[mark, nil, mark], [_, _, _]], player) when player == mark, do: %{row: 1, column: 1}
 	defp vertical_win([[mark, mark, nil], [_, _, _]], player) when player == mark, do: %{row: 2, column: 1}
 
-	defp vertical_win([[nil, mark, mark]|tail], player) when player == mark, do: %{row: 0, column: 0}
-	defp vertical_win([[mark, nil, mark]|tail], player) when player == mark, do: %{row: 1, column: 0}
-	defp vertical_win([[mark, mark, nil]|tail], player) when player == mark, do: %{row: 2, column: 0}
+	defp vertical_win([[nil, mark, mark]|_tail], player) when player == mark, do: %{row: 0, column: 0}
+	defp vertical_win([[mark, nil, mark]|_tail], player) when player == mark, do: %{row: 1, column: 0}
+	defp vertical_win([[mark, mark, nil]|_tail], player) when player == mark, do: %{row: 2, column: 0}
 
 	defp vertical_win([[_, _, _]|tail], player) , do: vertical_win(tail, player)
 
@@ -79,5 +79,5 @@ defmodule GameEngine.PlayStrategies.KickAssWinMoves do
 
 	defp diagonal_win({_, _, _, 
 					  _, _, _, 
-					  _, _, _}, player), do: nil
+					  _, _, _}, _player), do: nil
 end

--- a/game_engine/lib/game_engine/player.ex
+++ b/game_engine/lib/game_engine/player.ex
@@ -22,19 +22,19 @@ defmodule GameEngine.Player do
 		{:ok, state}
 	end
 
-	def handle_call({:initialize, name, type, mark, :computer_computer}, _from, state) do
+	def handle_call({:initialize, name, type, mark, :computer_computer}, _from, _state) do
 		state = %{name: name, type: type, mark: mark, strategy: :simple}
 
 		{:reply, {:ok, state}, state}
 	end
 
-	def handle_call({:initialize, name, :computer, mark, :human_computer}, _from, state) do
+	def handle_call({:initialize, name, :computer, mark, :human_computer}, _from, _state) do
 		state = %{name: name, type: :computer, mark: mark, strategy: :kickass}
 
 		{:reply, {:ok, state}, state}
 	end
 
-	def handle_call({:initialize, name, :human, mark, _game_type}, _from, state) do
+	def handle_call({:initialize, name, :human, mark, _game_type}, _from, _state) do
 		state = %{name: name, type: :human, mark: mark, strategy: :human}
 
 		{:reply, {:ok, state}, state}


### PR DESCRIPTION
Running mix compile --force --warnings-as-errors will show as all the warnings