### PR TITLE
Board dimension in single place

### DIFF
--- a/game_engine/lib/game_engine/board.ex
+++ b/game_engine/lib/game_engine/board.ex
@@ -1,10 +1,9 @@
 defmodule GameEngine.Board do
 
     @players [:o, :x]
+    @dimension 3
 
-    def get_empty(), do: {nil, nil, nil,
-                          nil, nil, nil,
-                          nil, nil, nil}
+    def get_empty(), do: for position <- 1..@dimension*@dimension, do: nil
 
     def resolve_winner({player, player, player,
                         _, _, _,

--- a/game_engine/lib/game_engine/board.ex
+++ b/game_engine/lib/game_engine/board.ex
@@ -1,44 +1,14 @@
 defmodule GameEngine.Board do
 
     @players [:o, :x]
-    @dimension 3
+    @board_dimension 3
 
-    def get_empty(), do: for position <- 1..@dimension*@dimension, do: nil
-
-    def resolve_winner({player, player, player,
-                        _, _, _,
-                        _, _, _}) when player in @players, do: :winner
-
-    def resolve_winner({_, _, _,
-                       player, player, player,
-                       _, _, _}) when player in @players, do: :winner
-
-    def resolve_winner({_, _, _,
-                        _, _, _,
-                        player, player, player}) when player in @players, do: :winner
-
-    def resolve_winner({player, _, _,
-                        player, _, _,
-                        player, _, _}) when player in @players, do: :winner
-
-    def resolve_winner({_, player, _,
-                        _, player, _,
-                        _, player, _}) when player in @players, do: :winner
-
-    def resolve_winner({_, _, player,
-                        _, _, player,
-                        _, _, player}) when player in @players, do: :winner
-
-    def resolve_winner({_, _, player,
-                        _, player, _,
-                        player, _, _}) when player in @players, do: :winner
-
-    def resolve_winner({player, _, _,
-                        _, player, _,
-                        _, _, player}) when player in @players, do: :winner
+    def get_empty(), do: for _position <- 1..@board_dimension*@board_dimension, do: nil
 
     def resolve_winner(board) do
         cond do
+            :winner == winner(board) ->
+                :winner
             full?(board) ->
                 :draw
             true ->
@@ -46,26 +16,70 @@ defmodule GameEngine.Board do
         end
     end
 
+    def winner(board) do
+        o_win = for _index <- 1..@board_dimension, do: :o
+        x_win = for _index <- 1..@board_dimension, do: :x
+        get_groups(board)
+        |> Enum.any?(fn(group) -> group == o_win or group == x_win end)
+        |> do_winner
+    end
+
     def full?(board) do
         board
-        |> Tuple.to_list
         |> Enum.all?(fn(position) -> position_occupied?(position) end)
     end
 
-    def get_by_position(positions, %{row: row, column: column}) do
-        positions
-        |> Tuple.to_list
+    def get_groups(board) do
+        get_rows(board) ++ get_columns(board) ++ get_diagonals(board)
+    end
+
+     def get_rows(board) do
+        board
+        |> Enum.chunk(@board_dimension)
+    end
+
+    def get_columns(board) do
+        for column_index <- 0..@board_dimension-1, do: get_column(column_index, board)
+    end
+
+    def get_column(column_index, board) do
+        board
+        |> Enum.drop(column_index)
+        |> Enum.take_every(@board_dimension)
+    end
+
+    def get_diagonals(board) do
+        [first_diagonal(board)|[second_diagonal(board)]]
+    end
+
+    def first_diagonal(board) do
+        first_diagonal_indexes = Stream.iterate(0, &(&1 + @board_dimension + 1))
+        |> Enum.take(@board_dimension)
+
+        for diagonal_index <- first_diagonal_indexes, do: Enum.at(board, diagonal_index)
+    end
+
+    def second_diagonal(board) do
+        second_diagonal_indexes = Stream.iterate(@board_dimension-1, &(&1 + @board_dimension - 1))
+        |> Enum.take(@board_dimension)
+
+        for diagonal_index <- second_diagonal_indexes, do: Enum.at(board, diagonal_index)
+    end
+
+    def get_by_position(board, %{row: row, column: column}) do
+        board
         |> Enum.at(get_index(row, column))
     end
 
-    def put_mark(positions, %{row: row, column: column}, mark) do
-        positions
+    def put_mark(board, %{row: row, column: column}, mark) do
+        board
+        |> List.to_tuple
         |> put_elem(get_index(row, column), mark)
+        |> Tuple.to_list
     end
 
-    def available_positions(positions) do
-        for position <- decompound_positions(positions),
-        {mark, index} = position,
+    def available_positions(board) do
+        for position <- decompound_positions(board), {mark, index} = position,
         !position_occupied?(mark) do
             row_column(index)
         end
@@ -73,14 +87,17 @@ defmodule GameEngine.Board do
 
     defp position_occupied?(mark), do: mark != nil
 
-    defp get_index(row, column), do: row * 3 + column
+    defp get_index(row, column), do: row * @board_dimension + column
 
-    defp decompound_positions(positions) do
-        positions |> Tuple.to_list |> Enum.with_index
+    defp decompound_positions(board) do
+        board |> Enum.with_index
     end
 
     defp row_column(index) do
-        %{row: div(index, 3), column: rem(index, 3)}
+        %{row: div(index, @board_dimension), column: rem(index, @board_dimension)}
     end
+
+    defp do_winner(true), do: :winner
+    defp do_winner(false), do: :no_winner
 
 end

--- a/game_engine/lib/game_engine/board.ex
+++ b/game_engine/lib/game_engine/board.ex
@@ -53,17 +53,21 @@ defmodule GameEngine.Board do
     end
 
     def first_diagonal(board) do
-        first_diagonal_indexes = Stream.iterate(0, &(&1 + @board_dimension + 1))
+        first_diagonal_indexes = Stream.iterate(0, fn(index) -> index + @board_dimension + 1 end)
         |> Enum.take(@board_dimension)
 
-        for diagonal_index <- first_diagonal_indexes, do: Enum.at(board, diagonal_index)
+        get_diagonal(first_diagonal_indexes, board)
     end
 
     def second_diagonal(board) do
-        second_diagonal_indexes = Stream.iterate(@board_dimension-1, &(&1 + @board_dimension - 1))
+        second_diagonal_indexes = Stream.iterate(@board_dimension-1, fn(index) -> index + @board_dimension - 1 end)
         |> Enum.take(@board_dimension)
 
-        for diagonal_index <- second_diagonal_indexes, do: Enum.at(board, diagonal_index)
+        get_diagonal(second_diagonal_indexes, board)
+    end
+
+    def get_diagonal(diagonal_indexes, board) do
+        for diagonal_index <- diagonal_indexes, do: Enum.at(board, diagonal_index)
     end
 
     def get_by_position(board, %{row: row, column: column}) do

--- a/game_engine/lib/game_engine/game.ex
+++ b/game_engine/lib/game_engine/game.ex
@@ -40,23 +40,22 @@ defmodule GameEngine.Game do
     end
 
     def handle_call({:move, _game_id}, _from, state) do
-        board = GameEngine.Player.move(state[:board], state[:next_player])
+        new_board = GameEngine.Player.move(state[:board], state[:next_player])
 
-        game_status = get_status(board)
-        {player, next_player} = swap_players(state[:next_player])
-
-        state = %{state | status: game_status, board: board, player: player, next_player: next_player}
-
-        {:reply, {:ok, state}, state}
+        apply_move(new_board, state)
     end
 
     def handle_call({:move, _game_id, position}, _from, state) do
-        board = GameEngine.Player.move(state[:board], position, state[:next_player])
+        new_board = GameEngine.Player.move(state[:board], position, state[:next_player])
 
-        game_status = get_status(board)
+        apply_move(new_board, state)
+    end
+
+    def apply_move(new_board, state) do
+        game_status = get_status(new_board)
         {player, next_player} = swap_players(state[:next_player])
 
-        state = %{state | status: game_status, board: board, player: player, next_player: next_player}
+        state = %{state | status: game_status, board: new_board, player: player, next_player: next_player}
 
         {:reply, {:ok, state}, state}
     end

--- a/game_engine/lib/game_engine/player.ex
+++ b/game_engine/lib/game_engine/player.ex
@@ -1,21 +1,18 @@
 defmodule GameEngine.Player do
 
     def move(board, mark) do
-        cond do
-            GameEngine.Board.full?(board) ->
-                board
+        case GameEngine.Board.full?(board) do
             true ->
-                GameEngine.Minimax.calculate_move(board, mark)
-                |> put_mark(board, mark)
+                board
+            false ->
+                position = GameEngine.Minimax.calculate_move(board, mark)
+                GameEngine.Board.put_mark(board, position, mark)
         end
     end
 
     def move(board, position, mark) do
         GameEngine.Board.put_mark(board, position, mark)
     end
-
-    defp put_mark(:not_found, board, _mark), do: board
-    defp put_mark(position, board, mark), do: GameEngine.Board.put_mark(board, position, mark)
 
     def know_your_enemy(:o), do: :x
     def know_your_enemy(:x), do: :o

--- a/game_engine/test/controllers/engine_controller_test.exs
+++ b/game_engine/test/controllers/engine_controller_test.exs
@@ -6,7 +6,7 @@ defmodule GameEngine.EngineControllerTest do
     test "get started game" do
         with_mock GameEngine.Game, [:passthrough],
         [start: fn(_game, _players) ->
-            {:ok, %{game_id: "", board: {}, next_player: :o, x: :computer, o: :computer, type: :computer_computer}} end] do
+            {:ok, %{game_id: "", board: [], next_player: :o, x: :computer, o: :computer, type: :computer_computer}} end] do
 
             response = GameEngine.EngineController.start(conn, %{"o" => "computer", "x" => "computer", "first_player" => "O"})
 
@@ -19,7 +19,7 @@ defmodule GameEngine.EngineControllerTest do
         game_id = "38c5c34f-6d33-4618-bb5f-9a9f1890ff8d"
         with_mock GameEngine.Game, [:passthrough],
         [start: fn(_game, _players) ->
-            {:ok, %{game_id: game_id, board: {}, next_player: :o, x: :computer, o: :computer, type: :computer_computer}} end] do
+            {:ok, %{game_id: game_id, board: [], next_player: :o, x: :computer, o: :computer, type: :computer_computer}} end] do
 
             response = GameEngine.EngineController.start(conn, %{"o" => "computer", "x" => "computer", "first_player" => "O"})
 
@@ -31,7 +31,7 @@ defmodule GameEngine.EngineControllerTest do
     test "get empty board when game started" do
         with_mock GameEngine.Game, [:passthrough],
         [start: fn(_game, _players) ->
-            {:ok, %{game_id: "", board: {nil, nil, nil, nil, nil, nil, nil, nil, nil}, next_player: :o, x: :computer, o: :computer, type: :computer_computer}} end] do
+            {:ok, %{game_id: "", board: [nil, nil, nil, nil, nil, nil, nil, nil, nil], next_player: :o, x: :computer, o: :computer, type: :computer_computer}} end] do
 
             response = GameEngine.EngineController.start(conn, %{"o" => "computer", "x" => "computer", "first_player" => "O"})
 
@@ -43,7 +43,7 @@ defmodule GameEngine.EngineControllerTest do
     test "get players for started game" do
         with_mock GameEngine.Game, [:passthrough],
         [start: fn(_game, _players) ->
-            {:ok, %{game_id: "", board: {}, next_player: :o, x: :computer, o: :computer, type: :computer_computer}} end] do
+            {:ok, %{game_id: "", board: [], next_player: :o, x: :computer, o: :computer, type: :computer_computer}} end] do
 
             response = GameEngine.EngineController.start(conn, %{"o" => "computer", "x" => "computer", "first_player" => "O"})
 
@@ -56,7 +56,7 @@ defmodule GameEngine.EngineControllerTest do
     test "get type of game" do
         with_mock GameEngine.Game, [:passthrough],
         [start: fn(_game, _players) ->
-            {:ok, %{game_id: "", board: {}, next_player: :o, x: :computer, o: :computer, type: :computer_computer}} end] do
+            {:ok, %{game_id: "", board: [], next_player: :o, x: :computer, o: :computer, type: :computer_computer}} end] do
 
             response = GameEngine.EngineController.start(conn, %{"o" => "computer", "x" => "computer", "first_player" => "O"})
 
@@ -68,7 +68,7 @@ defmodule GameEngine.EngineControllerTest do
     test "next player to play is the specified first player" do
         with_mock GameEngine.Game, [:passthrough],
         [start: fn(_game, _players) ->
-            {:ok, %{game_id: "", board: {}, next_player: :o, x: :computer, o: :computer, type: :computer_computer}} end] do
+            {:ok, %{game_id: "", board: [], next_player: :o, x: :computer, o: :computer, type: :computer_computer}} end] do
 
             response = GameEngine.EngineController.start(conn, %{"o" => "computer", "x" => "computer", "first_player" => "O"})
 
@@ -90,7 +90,7 @@ defmodule GameEngine.EngineControllerTest do
     test "get status returned by game upon player moves" do
         expected_status = :in_progress
         with_mock GameEngine.Game, [:passthrough],
-        [move: fn(_game, _game_id) -> {:ok, %{status: expected_status, player: :o, next_player: :x, board: {}}} end] do
+        [move: fn(_game, _game_id) -> {:ok, %{status: expected_status, player: :o, next_player: :x, board: []}} end] do
 
             response = GameEngine.EngineController.move(conn, %{"game_id" => "aa022760-c2c2-11e5-a5c7-3ca9f4aa918d"})
 
@@ -100,7 +100,7 @@ defmodule GameEngine.EngineControllerTest do
     end
 
     test "get board after player moves" do
-        board = {nil, nil, nil, nil, nil, :x, nil, nil, nil}
+        board = [nil, nil, nil, nil, nil, :x, nil, nil, nil]
         with_mock GameEngine.Game, [:passthrough],
             [move: fn(_game, _game_id) -> {:ok, %{board: board, status: "", player: :x, next_player: :o}} end] do
 
@@ -113,7 +113,7 @@ defmodule GameEngine.EngineControllerTest do
 
     test "get next player after player moves" do
         with_mock GameEngine.Game, [:passthrough],
-            [move: fn(_game, _game_id) -> {:ok, %{next_player: :o, player: :x, board: {}, status: ""}} end] do
+            [move: fn(_game, _game_id) -> {:ok, %{next_player: :o, player: :x, board: [], status: ""}} end] do
 
             response = GameEngine.EngineController.move(conn, %{"game_id" => "aa022760-c2c2-11e5-a5c7-3ca9f4aa918d"})
 
@@ -124,7 +124,7 @@ defmodule GameEngine.EngineControllerTest do
 
     test "get player that performed move" do
         with_mock GameEngine.Game, [:passthrough],
-            [move: fn(_game, _game_id) -> {:ok, %{player: :x, next_player: :o, board: {}, status: ""}} end] do
+            [move: fn(_game, _game_id) -> {:ok, %{player: :x, next_player: :o, board: [], status: ""}} end] do
 
             response = GameEngine.EngineController.move(conn, %{"game_id" => "aa022760-c2c2-11e5-a5c7-3ca9f4aa918d"})
 
@@ -136,7 +136,7 @@ defmodule GameEngine.EngineControllerTest do
     test "returns draw" do
         expected_status = :draw
         with_mock GameEngine.Game, [:passthrough],
-            [move: fn(_game, _game_id) -> {:ok, %{status: expected_status, player: :o, next_player: :x, board: {}}} end] do
+            [move: fn(_game, _game_id) -> {:ok, %{status: expected_status, player: :o, next_player: :x, board: []}} end] do
 
             response = GameEngine.EngineController.move(conn, %{"game_id" => "aa022760-c2c2-11e5-a5c7-3ca9f4aa918d"})
 
@@ -148,7 +148,7 @@ defmodule GameEngine.EngineControllerTest do
     test "human player moves" do
         with_mock GameEngine.Game, [:passthrough],
             [move: fn(_game, _game_id, _move) ->
-                {:ok, %{board: {nil, nil, nil, nil, nil, :x, nil, nil, nil}, status: "", player: :o, next_player: :x}} end] do
+                {:ok, %{board: [nil, nil, nil, nil, nil, :x, nil, nil, nil], status: "", player: :o, next_player: :x}} end] do
 
             response = GameEngine.EngineController.move(conn, %{"game_id" => "aa022760-c2c2-11e5-a5c7-3ca9f4aa918d", "move" => %{"column" => 1, "row" => 1}})
 

--- a/game_engine/test/lib/board_test.exs
+++ b/game_engine/test/lib/board_test.exs
@@ -7,116 +7,118 @@ defmodule GameEngine.BoardTest do
                                             nil, nil, nil]
     end
 
-    test "returns o as winner if it has completed first row" do
-        first_row_win = {:o, :o, :o,
-                          nil, nil, nil,
-                          nil, nil, nil}
+    test "get rows in board" do
+      board = [:o, :o, :o,
+               nil, nil, nil,
+               :x, :x, :x]
 
-        assert GameEngine.Board.resolve_winner(first_row_win) == :winner
+      assert GameEngine.Board.get_rows(board) == [[:o, :o, :o], [nil, nil, nil], [:x, :x, :x]]
     end
 
-    test "returns x as winner if it has completed first row" do
-        first_row_win = {:x, :x, :x,
-                          nil, nil, nil,
-                          nil, nil, nil}
+    test "get first column in board" do
+      board = [:o, :o, :o,
+               nil, nil, nil,
+               :x, :x, :x]
 
-        assert GameEngine.Board.resolve_winner(first_row_win) == :winner
+      assert GameEngine.Board.get_column(0, board) == [:o, nil, :x]
     end
 
-    test "returns player as winner if it has completed second row" do
-        second_row_win = {:o, nil, nil,
-                          :x, :x, :x,
-                          nil, nil, nil}
+    test "get columns in board" do
+      board = [:o, :o, :o,
+               nil, nil, nil,
+               :x, :x, :x]
 
-        assert GameEngine.Board.resolve_winner(second_row_win) == :winner
+      assert GameEngine.Board.get_columns(board) == [[:o, nil, :x], [:o, nil, :x], [:o, nil, :x]]
     end
 
-    test "returns player as winner if it has completed third row" do
-        third_row_win = {:o, nil, nil,
-                         :o, nil, nil,
-                         :x, :x, :x}
+    test "get first diagonal" do
+      board = [:o, nil, nil,
+               nil, :o, nil,
+               nil, nil, :o]
 
-        assert GameEngine.Board.resolve_winner(third_row_win) == :winner
+      assert GameEngine.Board.first_diagonal(board) == [:o, :o, :o]
     end
 
-    test "returns player as winner if it has completed first column" do
-        first_column_win = {:o, nil, nil,
-                            :o, nil, nil,
-                            :o, :x, :x}
+    test "get second diagonal" do
+      board = [nil, nil, :x,
+               nil, :x, nil,
+               :x, nil, nil]
 
-        assert GameEngine.Board.resolve_winner(first_column_win) == :winner
+      assert GameEngine.Board.second_diagonal(board) == [:x, :x, :x]
     end
 
-    test "returns player as winner if it has completed second column" do
-        second_column_win = {nil, :o, nil,
-                             nil, :o, nil,
-                             nil, :o, :x}
+    test "get diagonals" do
+      board = [nil, nil, :x,
+               nil, :x, nil,
+               :x, nil, nil]
 
-        assert GameEngine.Board.resolve_winner(second_column_win) == :winner
+      assert GameEngine.Board.get_diagonals(board) == [[nil, :x, nil], [:x, :x, :x]]
     end
 
-    test "returns player as winner if it has completed third column" do
-        third_column_win = {nil, nil, :x,
-                            nil, nil, :x,
-                            nil, nil, :x}
+    test "get groups" do
+      board = [nil, nil, :x,
+               nil, :x, nil,
+               :x, nil, nil]
 
-        assert GameEngine.Board.resolve_winner(third_column_win) == :winner
+      assert GameEngine.Board.get_groups(board) == [[nil, nil, :x], [nil, :x, nil], [:x, nil, nil],
+                                                    [nil, nil, :x], [nil, :x, nil], [:x, nil, nil],
+                                                    [nil, :x, nil], [:x, :x, :x]]
     end
 
-    test "returns player as winner if it has completed diagonal" do
-        diagonal_win = {nil, nil, :o,
-                        nil, :o, nil,
-                        :o, nil, nil}
+    test "winner when O has completed first diagonal" do
+        first_diagonal_win = [:o, :x, :x,
+                              nil, :o, nil,
+                              nil, nil, :o]
 
-        assert GameEngine.Board.resolve_winner(diagonal_win) == :winner
+        assert GameEngine.Board.winner(first_diagonal_win) == :winner
     end
 
-    test "returns player as winner if it has completed back diagonal" do
-        back_diagonal_win = {:o, nil, nil,
-                             nil, :o, nil,
-                             nil, nil, :o}
+    test "returns winner when O has completed first diagonal" do
+        first_diagonal = [:o, :x, :x,
+                          nil, :o, nil,
+                          nil, nil, :o]
 
-        assert GameEngine.Board.resolve_winner(back_diagonal_win) == :winner
+        assert GameEngine.Board.resolve_winner(first_diagonal) == :winner
     end
 
     test "returns draw when all positions are occupied" do
-        full_board = {:o, :o, :x,
+        full_board = [:o, :o, :x,
                       :x, :x, :o,
-                      :o, :x, :x}
+                      :o, :x, :x]
 
         assert GameEngine.Board.resolve_winner(full_board) == :draw
     end
 
     test "no result when board has spare positions" do
-        board_with_spare_positions = {:o, :o, :x,
+        board_with_spare_positions = [:o, :o, :x,
                                       :x, nil, :o,
-                                      :o, :x, :x}
+                                      :o, :x, :x]
 
         assert GameEngine.Board.resolve_winner(board_with_spare_positions) == :no_result
     end
 
     test "get a mark by given position" do
-        positions = {:o, nil, nil,
+        positions = [:o, nil, nil,
                      nil, nil, nil,
-                     nil, nil, nil}
+                     nil, nil, nil]
 
         assert GameEngine.Board.get_by_position(positions, %{row: 0, column: 0}) == :o
     end
 
     test "put a mark in given position" do
-        positions = {nil, nil, nil,
+        board = [nil, nil, nil,
                      nil, nil, nil,
-                     nil, nil, nil}
+                     nil, nil, nil]
         position = %{row: 0, column: 0}
-        board = GameEngine.Board.put_mark(positions, position, :o)
+        board = GameEngine.Board.put_mark(board, position, :o)
 
         assert GameEngine.Board.get_by_position(board, position) == :o
     end
 
     test "find two available positions in the board" do
-        board_with_two_available_positions = {nil, nil, :o,
+        board_with_two_available_positions = [nil, nil, :o,
                                               :x, :o, :o,
-                                              :x, :o, :x}
+                                              :x, :o, :x]
 
         available_positions = GameEngine.Board.available_positions(board_with_two_available_positions)
 
@@ -124,9 +126,9 @@ defmodule GameEngine.BoardTest do
     end
 
     test "find four available positions in the board" do
-        board_with_four_available_positions = {nil, nil, :o,
+        board_with_four_available_positions = [nil, nil, :o,
                                               :x, :o, nil,
-                                              nil, :o, :x}
+                                              nil, :o, :x]
 
         available_positions = GameEngine.Board.available_positions(board_with_four_available_positions)
 

--- a/game_engine/test/lib/board_test.exs
+++ b/game_engine/test/lib/board_test.exs
@@ -2,9 +2,9 @@ defmodule GameEngine.BoardTest do
     use ExUnit.Case
 
     test "get empty board" do
-      assert GameEngine.Board.get_empty == {nil, nil, nil,
+      assert GameEngine.Board.get_empty == [nil, nil, nil,
                                             nil, nil, nil,
-                                            nil, nil, nil}
+                                            nil, nil, nil]
     end
 
     test "returns o as winner if it has completed first row" do

--- a/game_engine/test/lib/game_test.exs
+++ b/game_engine/test/lib/game_test.exs
@@ -3,7 +3,7 @@ defmodule GameEngine.GameTest do
 
     import Mock
 
-    @empty_board {nil, nil, nil, nil, nil, nil, nil, nil, nil}
+    @empty_board [nil, nil, nil, nil, nil, nil, nil, nil, nil]
 
     setup do
         {:ok, game} = GameEngine.Game.start_link

--- a/game_engine/test/lib/game_test.exs
+++ b/game_engine/test/lib/game_test.exs
@@ -96,7 +96,7 @@ defmodule GameEngine.GameTest do
     end
 
     test "game returns the board after player moves", %{game: game} do
-        board_after_move = {:o, nil, nil, nil, nil, nil, nil, nil, nil}
+        board_after_move = [:o, nil, nil, nil, nil, nil, nil, nil, nil]
         with_mock GameEngine.Player, [:passthrough], [move: fn(_board, _player) -> board_after_move end] do
             game_id = start_new_game(game, :o)
 
@@ -107,7 +107,7 @@ defmodule GameEngine.GameTest do
     end
 
     test "game status is winner if a player wins", %{game: game} do
-        with_mock GameEngine.Player, [:passthrough], [move: fn(_board, _player) -> {:o, :o, :o, :x, :x, :o, :o, :x, :o} end] do
+        with_mock GameEngine.Player, [:passthrough], [move: fn(_board, _player) -> [:o, :o, :o, :x, :x, :o, :o, :x, :o] end] do
             game_id = start_new_game(game, :o)
             {:ok, move} = GameEngine.Game.move(game, game_id)
 
@@ -116,7 +116,7 @@ defmodule GameEngine.GameTest do
     end
 
     test "game is a draw", %{game: game} do
-        with_mock GameEngine.Player, [:passthrough], [move: fn(_board, _player) -> {:o, :x, :x, :x, :o, :o, :x, :o, :x} end] do
+        with_mock GameEngine.Player, [:passthrough], [move: fn(_board, _player) -> [:o, :x, :x, :x, :o, :o, :x, :o, :x] end] do
             game_id = start_new_game(game, :o)
             {:ok, move} = GameEngine.Game.move(game, game_id)
 
@@ -125,7 +125,7 @@ defmodule GameEngine.GameTest do
     end
 
     test "game is in progress if no draw nor a winner", %{game: game} do
-        with_mock GameEngine.Player, [:passthrough], [move: fn(_board, _player) -> {:o, nil, nil, nil, nil, nil, nil, nil, nil} end] do
+        with_mock GameEngine.Player, [:passthrough], [move: fn(_board, _player) -> [:o, nil, nil, nil, nil, nil, nil, nil, nil] end] do
 
             game_id = start_new_game(game, :o)
             {:ok, move} = GameEngine.Game.move(game, game_id)

--- a/game_engine/test/lib/minimax_test.exs
+++ b/game_engine/test/lib/minimax_test.exs
@@ -9,24 +9,24 @@ defmodule GameEngine.MinimaxTest do
     @fake_position %{}
 
     test "calculates move based on minimax" do
-        board = {@opponent, nil, nil,
+        board = [@opponent, nil, nil,
                 nil, @player, nil,
-                nil, nil, @opponent}
+                nil, nil, @opponent]
 
         block_opponent_fork = %{row: 0, column: 1}
         assert GameEngine.Minimax.calculate_move(board, @player) == block_opponent_fork
     end
 
     test "finds win score and fake position when player wins" do
-        assert GameEngine.Minimax.inspect_result(:winner, @tagged_player, {}) == {@fake_position, -1}
+        assert GameEngine.Minimax.inspect_result(:winner, @tagged_player, []) == {@fake_position, -1}
     end
 
     test "finds loose score and fake position when opponent wins" do
-        assert GameEngine.Minimax.inspect_result(:winner, @tagged_opponent, {}) == {@fake_position, 1}
+        assert GameEngine.Minimax.inspect_result(:winner, @tagged_opponent, []) == {@fake_position, 1}
     end
 
     test "finds draw score and fake position if no winner" do
-        assert GameEngine.Minimax.inspect_result(:draw, @tagged_opponent, {}) == {@fake_position, 0}
+        assert GameEngine.Minimax.inspect_result(:draw, @tagged_opponent, []) == {@fake_position, 0}
     end
 
     test "defines initial best position for player out of range to ensure better score is found" do
@@ -46,7 +46,7 @@ defmodule GameEngine.MinimaxTest do
         assert GameEngine.Minimax.min_or_max(is_opponent, best, current_best) == best
     end
 
-    test "finds current best when not maximum for player" do
+    test "finds current best when intermediate score is not maximum for player" do
         intermediate = {%{row: 1, column: 1}, 0}
         current_best = {%{row: 0, column: 0}, 1}
         is_opponent = false
@@ -68,61 +68,61 @@ defmodule GameEngine.MinimaxTest do
     end
 
     test "finds win position for player when game is over" do
-        board = {@player, @player, @player,
+        board = [@player, @player, @player,
                  @opponent, @opponent, nil,
-                 @opponent, @opponent, nil}
+                 @opponent, @opponent, nil]
 
         assert GameEngine.Minimax.minimax(board, @tagged_player) == {@fake_position, -1}
     end
 
     test "finds loose position for player when game is over" do
-        board = {@player, @player, @opponent,
+        board = [@player, @player, @opponent,
                  @opponent, @opponent, nil,
-                 @opponent, @opponent, nil}
+                 @opponent, @opponent, nil]
 
         assert GameEngine.Minimax.minimax(board, @tagged_opponent) == {@fake_position, 1}
     end
 
     test "finds win position for player in next step" do
-        board = {@player, @player, nil,
+        board = [@player, @player, nil,
                  @opponent, @opponent, @player,
-                 @opponent, @opponent, @player}
+                 @opponent, @opponent, @player]
         win_position = %{row: 0, column: 2}
 
         assert GameEngine.Minimax.minimax(board, @tagged_player) == {win_position, 1}
     end
 
     test "finds loosing position in next step" do
-        board = {@player, @player, nil,
+        board = [@player, @player, nil,
                  @opponent, @opponent, nil,
-                 @opponent, @opponent, nil}
+                 @opponent, @opponent, nil]
 
         loosing_position = %{row: 0, column: 2}
         assert GameEngine.Minimax.minimax(board, @tagged_opponent) == {loosing_position, -1}
     end
 
     test "blocks opponent from winning in next step" do
-        board = {@player, @player, @opponent,
+        board = [@player, @player, @opponent,
                 nil, @opponent, @player,
-                nil, nil, @opponent}
+                nil, nil, @opponent]
 
         block_opponent = %{row: 2, column: 0}
         assert GameEngine.Minimax.minimax(board, @tagged_player) == {block_opponent, 0}
     end
 
     test "finds fork position leading to win in two steps for player" do
-        board = {@player, @opponent, nil,
+        board = [@player, @opponent, nil,
                 nil, @player, nil,
-                nil, nil, @opponent}
+                nil, nil, @opponent]
 
         fork = %{row: 1, column: 0}
         assert GameEngine.Minimax.minimax(board, @tagged_player) == {fork, 1}
     end
 
     test "blocks fork for opponent by attacking" do
-        board = {@opponent, nil, nil,
+        board = [@opponent, nil, nil,
                 nil, @player, nil,
-                nil, nil, @opponent}
+                nil, nil, @opponent]
 
         block_opponent_fork = %{row: 0, column: 1}
         assert GameEngine.Minimax.minimax(board, @tagged_player) == {block_opponent_fork, 0}

--- a/game_engine/test/lib/player_test.exs
+++ b/game_engine/test/lib/player_test.exs
@@ -3,7 +3,7 @@ defmodule GameEngine.PlayerTest do
 
     import Mock
 
-    @empty_board {nil, nil, nil, nil, nil, nil, nil, nil, nil}
+    @empty_board [nil, nil, nil, nil, nil, nil, nil, nil, nil]
     @player :o
     @opponent :x
 
@@ -26,9 +26,9 @@ defmodule GameEngine.PlayerTest do
     end
 
     test "player returns same board when no moves available" do
-        full_board = {@opponent, @player, @player,
+        full_board = [@opponent, @player, @player,
                       @player, @opponent, @opponent,
-                      @player, @opponent, @player}
+                      @player, @opponent, @player]
 
         assert GameEngine.Player.move(full_board, @player) == full_board
     end

--- a/game_engine/web/controllers/engine_controller.ex
+++ b/game_engine/web/controllers/engine_controller.ex
@@ -39,7 +39,7 @@ defmodule GameEngine.EngineController do
           type: type,
           o: o,
           x: x,
-          board: Tuple.to_list(board),
+          board: board,
           next_player: parse_player(next_player)}
     end
 
@@ -47,7 +47,7 @@ defmodule GameEngine.EngineController do
         %{game_id: game_id,
           status: status,
           player: parse_player(player),
-          board: Tuple.to_list(board),
+          board: board,
           next_player: parse_player(next_player)}
     end
 


### PR DESCRIPTION
Trying to abstract dimension of the board in a single place, for now a single constant definition in the Board module.

This way it will be easier to change to a game with a bigger board, it will be just modifying the code not to use this constant but some form of user's input.

Among other changes now we don't use pattern matching against a particular dimension of board to resolve winner. Rather we get all the groups and then trying to see if any of them is taken by a particular player 

Finally the board is now a list rather than a tuple. This means we can use straight away all the capabilities of Enum, rather than having to wrap/unwrap the tuple. 
